### PR TITLE
updated httplib2 version due version conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(  name='scioncc',
             'simplejson==3.6.5',
             'msgpack-python==0.1.13',  # TBD: Check if this specific version is needed
             'pika==0.9.5',             # Messaging stack is tested and working with issues of this version
-            'httplib2==0.9',
+            'httplib2==0.9.1',
             'zope.interface==4.1.1',
             'psycopg2==2.5.4',
             'numpy==1.9.1',


### PR DESCRIPTION
`bin/buildout` output:

```
Getting distribution for 'httplib2>=0.7'.
Running easy_install:
"/usr/bin/python" "-c" "from setuptools.command.easy_install import main; main()" "-mZUNxd" "/home/crchemist/ss/c/agprox/eggs/tmpz1Ly5H" "-q" "/tmp/tmpyEV5mkget_dist/httplib2-0.9.1.zip"
path=/usr/local/lib/python2.7/dist-packages
...
While:
  Installing agprox-project.
Error: There is a version conflict.
We already have: httplib2 0.9.1
but scioncc 3.0.0.dev0 requires 'httplib2==0.9'.
```