### PR TITLE
fixed issue with responses as tuples(resp, status_code)

### DIFF
--- a/src/ion/processes/ui/server.py
+++ b/src/ion/processes/ui/server.py
@@ -265,6 +265,9 @@ def enable_cors(resp):
     if ui_instance.develop_mode and ui_instance.set_cors_headers:
         if isinstance(resp, basestring):
             resp = Response(resp)
+        elif isinstance(resp, tuple):
+            resp, status_code = resp
+            resp.status_code = status_code
         resp.headers["Access-Control-Allow-Headers"] = "Origin, X-Atmosphere-tracking-id, X-Atmosphere-Framework, X-Cache-Date, Content-Type, X-Atmosphere-Transport, *"
         resp.headers["Access-Control-Allow-Methods"] = "POST, GET, OPTIONS , PUT"
         resp.headers["Access-Control-Allow-Origin"] = "*"

--- a/src/ion/util/ui_utils.py
+++ b/src/ion/util/ui_utils.py
@@ -56,8 +56,10 @@ def build_json_error():
     status = getattr(value, "status_code", 500)
     result = dict(error=dict(message=value.message, exception=type.__name__, trace=traceback.format_exc()),
                   status=status)
+    json_resp = jsonify(result)
+    json_resp.status_code = status
 
-    return jsonify(result), status
+    return json_resp, status
 
 
 def get_arg(arg_name, default="", is_mult=False):


### PR DESCRIPTION
```
pyon.net.endpoint: DEBUG: server exception being passed to client
   ----- NotFound: 404 - Invalid password -----
y2.7-linux-x86_64.egg/gevent/greenlet.py:327    result = self._run(*self.args, **self.kwargs)
x/extern/scioncc/src/pyon/ion/process.py:375    res = call(*callargs, **callkwargs)
/services/identity_management_service.py:183    raise NotFound("Invalid password")
xtern/scioncc/src/pyon/core/exception.py:24     super(IonException, self).__init__(*args, **kwargs)
ox/extern/scioncc/src/putil/exception.py:19     self._stack_init = traceback.extract_stack()
rpc: DEBUG: MESSAGE SEND <<< RPC-reply: ###u-14_8966.6(identity_management)### -> scion.system,amq.gen-RUPUlSqxB3K5XE97yzDA0w status=404:
HEADERS: {'conv-seq': 2, 'original-conv-id': 'u-14_8966-49', 'sender-service': 'scion.system,identity_management', 'protocol': 'rpc', 'sender': 'u-14_8966.6', 'language': 'ion-r2', 'format': 'list', 'ion-actor-tokens': ["(ipyon.core.governance.policy.policy_interceptor\nPolicyToken\np0\n(dp1\nS'originator'\np2\nS'u-14_8966'\np3\nsS'expire_time'\np4\nI1429099757975\nsS'token'\np5\nS'PERMIT_SUB_CALLS'\np6\nsS'actor_id'\np7\nS'anonymous'\np8\nsS'requesting_message'\np9\nS'identity_management_check_actor_credentials_in'\np10\nsb."], 'status_code': 404, 'encoding': 'msgpack', 'ts': '1429099728281', 'origin-container-id': 'u-14_8966', 'sender-name': 'identity_management', 'error_message': 'Invalid password', 'receiver': 'scion.system,amq.gen-RUPUlSqxB3K5XE97yzDA0w', 'conv-id': 'u-14_8966-49', 'performative': 'failure', 'sender-type': 'service'}
CONTENT: [('NotFound: 404 - Invalid password', [('/home/crchemist/ss/c/agprox/eggs/gevent-1.0.1-py2.7-linux-x86_64.egg/gevent/greenlet.py', 327, 'run', 'result = self._run(*self.args, **self.kwargs)'), ('/home/crchemist/ss/c/agprox/extern/scioncc/src/pyon/ion/process.py', 375, '_control_flow', 'res = call(*callargs, **callkwargs)'), ('/home/crchemist/ss/c/agprox/extern/scioncc/src/ion/services/identity_man...
rpc: DEBUG: MESSAGE RECV >>> RPC-reply: u-14_8966.6(identity_management) -> ###scion.system,amq.gen-RUPUlSqxB3K5XE97yzDA0w### status=404:
HEADERS: {'conv-seq': 2, 'origin-container-id': 'u-14_8966', 'original-conv-id': 'u-14_8966-49', 'error_message': 'Invalid password', 'protocol': 'rpc', 'sender': 'u-14_8966.6', 'language': 'ion-r2', 'format': 'list', 'status_code': 404, 'sender-service': 'scion.system,identity_management', 'routing_key': 'amq.gen-RUPUlSqxB3K5XE97yzDA0w', 'ion-actor-tokens': ["(ipyon.core.governance.policy.policy_interceptor\nPolicyToken\np0\n(dp1\nS'originator'\np2\nS'u-14_8966'\np3\nsS'expire_time'\np4\nI1429099757975\nsS'token'\np5\nS'PERMIT_SUB_CALLS'\np6\nsS'actor_id'\np7\nS'anonymous'\np8\nsS'requesting_message'\np9\nS'identity_management_check_actor_credentials_in'\np10\nsb."], 'ts': '1429099728281', 'encoding': 'msgpack', 'sender-name': 'identity_management', 'receiver': 'scion.system,amq.gen-RUPUlSqxB3K5XE97yzDA0w', 'conv-id': 'u-14_8966-49', 'performative': 'failure', 'sender-type': 'service'}
CONTENT: [['NotFound: 404 - Invalid password', [['/home/crchemist/ss/c/agprox/eggs/gevent-1.0.1-py2.7-linux-x86_64.egg/gevent/greenlet.py', 327, 'run', 'result = self._run(*self.args, **self.kwargs)'], ['/home/crchemist/ss/c/agprox/extern/scioncc/src/pyon/ion/process.py', 375, '_control_flow', 'res = call(*callargs, **callkwargs)'], ['/home/crchemist/ss/c/agprox/extern/scioncc/src/ion/services/identity_man...
pyon.net.endpoint: INFO: RPCRequestEndpointUnit received an error (404): Invalid password
ui_server: ERROR: Exception on /auth/login [POST]
   ----- exception: 'tuple' object has no attribute 'headers' -----
lib/python2.7/dist-packages/flask/app.py:1817   response = self.full_dispatch_request()
lib/python2.7/dist-packages/flask/app.py:1477   rv = self.handle_user_exception(e)
lib/python2.7/dist-packages/flask/app.py:1381   reraise(exc_type, exc_value, tb)
lib/python2.7/dist-packages/flask/app.py:1475   rv = self.dispatch_request()
lib/python2.7/dist-packages/flask/app.py:1461   return self.view_functions[rule.endpoint](**req.view_args)
n/scioncc/src/ion/processes/ui/server.py:280    return enable_cors(ui_instance.login())
n/scioncc/src/ion/processes/ui/server.py:268    resp.headers["Access-Control-Allow-Headers"] = "Origin, X-Atmosphere-tracking-id, X-Atmosphere-Framework, X-Cache-Date, Content-Type, X-Atmosphere-Transport, *"
requests.packages.urllib3.connectionpool: DEBUG: "POST /auth/login HTTP/1.1" 500 291
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 2 tests in 8.381s

FAILED (failures=1)
```