### PR TITLE
AG-1326: fix issue related to IN on empty lists.

### DIFF
--- a/src/pyon/datastore/datastore_query.py
+++ b/src/pyon/datastore/datastore_query.py
@@ -243,7 +243,7 @@ class DatastoreQueryBuilder(DatastoreQueryConst):
 
     def eq_in(self, col, expr):
         """Filter to list of values if type iterable else value equality"""
-        if type(expr) in (list, tuple):
+        if expr and type(expr) in (list, tuple):
             return self.in_(col, *expr)
         else:
             return self.eq(col, expr)


### PR DESCRIPTION
```
    assocs = self.rr.find_associations(query=aq.get_query(), id_only=False)
  File "/home/crchemist/scioncc/src/pyon/ion/resregistry.py", line 705, in find_associations
    query=query, limit=limit, skip=skip, descending=descending, access_args=access_args)
  File "/home/crchemist/scioncc/src/pyon/datastore/postgresql/datastore.py", line 256, in find_associations
    return self.find_by_query(query)
  File "/home/crchemist/scioncc/src/pyon/datastore/postgresql/datastore.py", line 746, in find_by_query
    cur.execute(exec_query, pqb.get_values())
  File "/home/crchemist/scioncc/src/pyon/datastore/postgresql/pg_util.py", line 284, in execute
    res = super(TracingCursor, self).execute(query, vars)
ProgrammingError: syntax error at or near ")"
LINE 1: ...LECT id,doc FROM ion_resources_assoc WHERE (o IN () AND st='...
```
