### PR TITLE
AX-9: fix the "refresh token" method

### DIFF
--- a/src/ion/process/ui/server.py
+++ b/src/ion/process/ui/server.py
@@ -452,7 +452,7 @@ def save_token(token, request, *args, **kwargs):
     token_obj = SecurityToken(token_type=TokenTypeEnum.OAUTH_ACCESS, token_string=access_token_str,
                               expires=expires, status="OPEN", actor_id=actor_id,
                               attributes=dict(access_token=access_token_str, refresh_token=refresh_token_str,
-                                              scopes=scopes, client_id=flask.g.client_id, ts_created=current_time))
+                                              scopes=scopes, client_id=request.client.client_id, ts_created=current_time))
     token_id = "access_token_%s" % access_token_str
     ui_instance.container.object_store.create(token_obj, token_id)
 
@@ -460,7 +460,7 @@ def save_token(token, request, *args, **kwargs):
     token_obj = SecurityToken(token_type=TokenTypeEnum.OAUTH_REFRESH, token_string=refresh_token_str,
                               expires=expires, status="OPEN", actor_id=actor_id,
                               attributes=dict(access_token=access_token_str, refresh_token=refresh_token_str,
-                                              scopes=scopes, client_id=flask.g.client_id, ts_created=current_time))
+                                              scopes=scopes, client_id=request.client.client_id, ts_created=current_time))
     token_id = "refresh_token_%s" % refresh_token_str
     ui_instance.container.object_store.create(token_obj, token_id)
 


### PR DESCRIPTION
Changes:
1) Used "request.client.client_id" instead of the "agprox_ui" constant in the "save_token" method for storing the "client_id" property of the "SecurityToken" entity to the DB.
2) Added the "test_ui_oauth2_refresh_token" test.

How it can be tested:
1.1) `curl -X POST http://localhost:4000/oauth/token -H "Content-Type:application/x-www-form-urlencoded; charset=UTF-8" -d "client_id=***&grant_type=password&username=***&password=***"`
1.2) `curl -X POST http://localhost:4000/oauth/token -H "Content-Type:application/x-www-form-urlencoded; charset=UTF-8" -d "client_id=***&grant_type=refresh_token&refresh_token=***"`
2) `bin/nosetests ion.process.ui.test.test_ui_server`
