### PR TITLE
AX-438: Enhance get typed value

### DIFF
--- a/src/ion/util/parse_utils.py
+++ b/src/ion/util/parse_utils.py
@@ -69,6 +69,8 @@ def get_typed_value(value, schema_entry=None, targettype=None, strict=False):
     elif targettype == 'float':
         if type(value) == float:
             return value
+        elif type(value) in (int, long):
+            return float(value)
         if strict:
             raise BadRequest("Value %s is type %s not float" % (value, type(value).__name__))
         try:

--- a/src/ion/util/test/test_parse_utils.py
+++ b/src/ion/util/test/test_parse_utils.py
@@ -47,6 +47,8 @@ class TestParseUtils(UnitTestCase):
             get_typed_value("", targettype="float", strict=False)
         ret_val = get_typed_value("999.9", targettype="float", strict=False)
         self.assertEqual(ret_val, 999.9)
+        ret_val = get_typed_value("999", targettype="float", strict=False)
+        self.assertEqual(ret_val, 999.0)
 
         # TEST: String
         ret_val = get_typed_value("foo", targettype="str", strict=True)


### PR DESCRIPTION
1) Modified the "get_typed_value" function. Allow sending int values in the float arguments of API calls.
2) Changed the "test_get_typed_value" tests.
